### PR TITLE
Inital MD feature - Support of links

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,11 @@
     "variant": "cpp",
     "vector": "cpp",
     "algorithm": "cpp",
-    "bit": "cpp"
-  }
+    "bit": "cpp",
+    "__functional_base": "cpp",
+    "functional": "cpp",
+    "iterator": "cpp",
+    "utility": "cpp"
+  },
+  "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/data/markdown/palpatine.md
+++ b/data/markdown/palpatine.md
@@ -1,0 +1,3 @@
+Sample data to show it is supporting markdown 
+
+This is the *[Markdown Guide](https://www.markdownguide.org)*.


### PR DESCRIPTION
Hello, I finally implemented the markdown file support for the links. I have added a `markdown.md` file in the sample data directory where you also have other txt files. I used `regex C++ library` to parse links and kept the code style as it was before. 
Here is an working example from my machine;
<img width="725" alt="CleanShot 2022-09-21 at 19 24 20@2x" src="https://user-images.githubusercontent.com/71540402/191627136-c7138a77-ce0c-4db3-af74-4e1cc1fe1f56.png">
